### PR TITLE
Redesign settings page with dark theme and checkbox layout

### DIFF
--- a/src/components/MqtLayout.css
+++ b/src/components/MqtLayout.css
@@ -138,6 +138,58 @@ body {
   max-width: 1200px;
 }
 
+/* Section cards for better grouping */
+.settings-section-card {
+  background: #0f0f0f;
+  border: 1px solid #1f1f1f;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+/* Inline field grid for numeric inputs */
+.inline-fields {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 900px) {
+  .inline-fields {
+    grid-template-columns: repeat(3, minmax(180px, 1fr));
+  }
+}
+
+/* Dark theme overrides for MUI inputs/labels */
+.mqt-settings-panel .MuiInputBase-input {
+  color: #ffffff;
+}
+.mqt-settings-panel .MuiFormLabel-root {
+  color: #bbbbbb;
+}
+.mqt-settings-panel .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline {
+  border-color: #444444;
+}
+.mqt-settings-panel .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline {
+  border-color: #666666;
+}
+.mqt-settings-panel .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #888888;
+}
+.mqt-settings-panel .MuiFormHelperText-root {
+  color: #aaaaaa;
+}
+
+/* Checkbox/text colors */
+.mqt-settings-panel .MuiFormControlLabel-label {
+  color: #ffffff;
+}
+.mqt-settings-panel .MuiCheckbox-root {
+  color: #90caf9;
+}
+.mqt-settings-panel .MuiCheckbox-root.Mui-checked {
+  color: #42a5f5;
+}
+
 /* Page title */
 .mqt-settings-title {
   font-size: 2rem;
@@ -169,10 +221,10 @@ body {
 .settings-section h3 {
   font-size: 1rem;
   font-weight: 600;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.75rem;
   color: #ffffff;
   border-bottom: 1px solid #333333;
-  padding-bottom: 0.25rem;
+  padding-bottom: 0.4rem;
 }
 
 /* Actions row */

--- a/src/components/MqtLayout.css
+++ b/src/components/MqtLayout.css
@@ -124,9 +124,10 @@ body {
   max-width: 600px;
   margin: 2rem auto;
   padding: 2rem;
-  background-color: #ffffff;
+  background-color: #000000;
+  color: #ffffff;
   border-radius: 16px;
-  box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -134,7 +135,7 @@ body {
 
 /* Wider container variant for two-column layout */
 .mqt-settings-wide {
-  max-width: 1000px;
+  max-width: 1200px;
 }
 
 /* Page title */
@@ -142,7 +143,7 @@ body {
   font-size: 2rem;
   font-weight: 600;
   margin: 0;
-  color: #222;
+  color: #ffffff;
 }
 
 /* Grid layout for settings columns */
@@ -169,8 +170,8 @@ body {
   font-size: 1rem;
   font-weight: 600;
   margin: 0 0 0.5rem;
-  color: #222;
-  border-bottom: 1px solid #e0e0e0;
+  color: #ffffff;
+  border-bottom: 1px solid #333333;
   padding-bottom: 0.25rem;
 }
 
@@ -188,8 +189,8 @@ body {
   font-size: 1.25rem;
   font-weight: 600;
   padding-bottom: 0.3rem;
-  border-bottom: 1px solid #e0e0e0;
-  color: #222;
+  border-bottom: 1px solid #333333;
+  color: #ffffff;
   margin-bottom: 0.5rem;
 }
 

--- a/src/components/MqtLayout.css
+++ b/src/components/MqtLayout.css
@@ -132,6 +132,58 @@ body {
   gap: 1.5rem;
 }
 
+/* Wider container variant for two-column layout */
+.mqt-settings-wide {
+  max-width: 1000px;
+}
+
+/* Page title */
+.mqt-settings-title {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0;
+  color: #222;
+}
+
+/* Grid layout for settings columns */
+.mqt-settings-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@media (min-width: 900px) {
+  .mqt-settings-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* Section blocks */
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-section h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: #222;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 0.25rem;
+}
+
+/* Actions row */
+.settings-actions {
+  text-align: center;
+  margin-top: 1.5rem;
+}
+
+.settings-actions .btn + .btn {
+  margin-left: 0.5rem;
+}
+
 .mqt-settings-panel h2 {
   font-size: 1.25rem;
   font-weight: 600;

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  Typography, Slider, Checkbox, FormControlLabel,
+  Typography, Checkbox, FormControlLabel,
   TextField, Button, Stack
 } from '@mui/material';
 import './MqtLayout.css';
@@ -163,63 +163,7 @@ const MqtSetting = () => {
   // SECTION: Timer settings (duration + format + some core toggles)
   const TimerSettings = (
     <Stack spacing={2}>
-      {timeFormat === 'mm:ss' ? (
-        <>
-          <Typography variant="body2">
-            Duration: {Math.floor(durationSec / 60)} min {durationSec % 60} sec
-          </Typography>
-          <Stack direction="row" spacing={1}>
-            <TextField
-              fullWidth
-              size="small"
-              type="number"
-              label="Minutes"
-              value={Math.floor(durationSec / 60)}
-              onChange={(e) => {
-                const maxSeconds = limitBreak ? 43200 * 60 : 120 * 60;
-                const currentSeconds = durationSec % 60;
-                const nextMinutes = Math.max(0, Math.min(maxSeconds / 60, parseInt(e.target.value || '0', 10)));
-                const nextDuration = Math.max(1, Math.min(maxSeconds, nextMinutes * 60 + currentSeconds));
-                setDurationSec(nextDuration);
-              }}
-              inputProps={{ min: 0, max: limitBreak ? 43200 : 120 }}
-            />
-            <TextField
-              fullWidth
-              size="small"
-              type="number"
-              label="Seconds"
-              value={durationSec % 60}
-              onChange={(e) => {
-                const maxSeconds = limitBreak ? 43200 * 60 : 120 * 60;
-                const secondsVal = Math.max(0, Math.min(59, parseInt(e.target.value || '0', 10)));
-                const minutesPart = Math.floor(durationSec / 60);
-                const nextDuration = Math.max(1, Math.min(maxSeconds, minutesPart * 60 + secondsVal));
-                setDurationSec(nextDuration);
-              }}
-              inputProps={{ min: 0, max: 59 }}
-            />
-          </Stack>
-          <Slider
-            size="small"
-            min={1}
-            max={limitBreak ? 43200 * 60 : 120 * 60}
-            value={durationSec}
-            onChange={(e, v) => setDurationSec(v)}
-          />
-        </>
-      ) : (
-        <>
-          <Typography variant="body2">Duration: {Math.floor(durationSec / 60)} min</Typography>
-          <Slider
-            size="small"
-            min={1}
-            max={limitBreak ? 43200 : 120}
-            value={Math.max(1, Math.floor(durationSec / 60))}
-            onChange={(e, v) => setDurationSec(Math.max(1, v) * 60)}
-          />
-        </>
-      )}
+      <></>
 
       <Typography variant="body2">Time Format</Typography>
       <Stack direction="row" spacing={2}>

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -3,8 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import {
   Box, Typography, Slider, Checkbox, FormControlLabel,
   Select, MenuItem, TextField, Button, FormControl, InputLabel,
-  Tabs, Tab, Stack
+  Stack
 } from '@mui/material';
+import './MqtLayout.css';
 
 // Local Storage helpers
 const STORAGE_KEY = 'mqt-timer-settings';
@@ -55,7 +56,7 @@ const MqtSetting = () => {
 
   // Load saved settings or use defaults
   const savedSettings = loadSettings() || {};
-  const [tabIndex, setTabIndex] = useState(savedSettings.tabIndex || 0);
+  const [tabIndex, setTabIndex] = useState(savedSettings.tabIndex || 0); // preserved for storage compatibility
   const initialDurationSec = (() => {
     const raw = savedSettings.duration ?? 600; // default 10 minutes in seconds
     if (savedSettings.durationUnit === 'sec') return Math.max(1, raw);
@@ -82,8 +83,6 @@ const MqtSetting = () => {
   const [hideClockBackground, setHideClockBackground] = useState(savedSettings.hideClockBackground || false);
   const [circleProgress, setCircleProgress] = useState(savedSettings.circleProgress || 'full');
   const [allowClickableTimer, setAllowClickableTimer] = useState(savedSettings.allowClickableTimer || false);
-
-  const handleTabChange = (_, newValue) => setTabIndex(newValue);
 
   // Save settings to localStorage whenever they change
   useEffect(() => {
@@ -162,6 +161,7 @@ const MqtSetting = () => {
     navigate(`/display?${params.toString()}`);
   };
 
+  // SECTION: Timer settings (duration + format + some core toggles)
   const TimerSettings = (
     <Stack spacing={2}>
       {timeFormat === 'mm:ss' ? (
@@ -221,9 +221,7 @@ const MqtSetting = () => {
           />
         </>
       )}
-      <FormControlLabel control={<Checkbox size="small" checked={autoRestart} onChange={() => setAutoRestart(!autoRestart)} />} label="Auto Restart" />
-      <FormControlLabel control={<Checkbox size="small" checked={countUp} onChange={() => setCountUp(!countUp)} />} label="Count Up (Reverse)" />
-      <FormControlLabel control={<Checkbox size="small" checked={limitBreak} onChange={() => setLimitBreak(!limitBreak)} />} label="Limit Break (exceed 120 min)" />
+
       <FormControl fullWidth size="small">
         <InputLabel>Time Format</InputLabel>
         <Select value={timeFormat} label="Time Format" onChange={(e) => setTimeFormat(e.target.value)}>
@@ -231,14 +229,16 @@ const MqtSetting = () => {
           <MenuItem value="mm:ss">MM:SS</MenuItem>
         </Select>
       </FormControl>
+
+      <FormControlLabel control={<Checkbox size="small" checked={autoRestart} onChange={() => setAutoRestart(!autoRestart)} />} label="Auto Restart" />
+      <FormControlLabel control={<Checkbox size="small" checked={countUp} onChange={() => setCountUp(!countUp)} />} label="Count Up (Reverse)" />
+      <FormControlLabel control={<Checkbox size="small" checked={limitBreak} onChange={() => setLimitBreak(!limitBreak)} />} label="Limit Break (exceed 120 min)" />
     </Stack>
   );
 
+  // SECTION: Functional controls
   const FunctionSettings = (
     <Stack spacing={2}>
-      <FormControlLabel control={<Checkbox size="small" checked={disableKeyboard} onChange={() => setDisableKeyboard(!disableKeyboard)} />} label="Disable Keyboard Shortcut" />
-      <FormControlLabel control={<Checkbox size="small" checked={allowClickableTimer} onChange={() => setAllowClickableTimer(!allowClickableTimer)} />} label="Allow Clickable Timer when running" />
-      <FormControlLabel control={<Checkbox size="small" checked={hideClockBackground} onChange={() => setHideClockBackground(!hideClockBackground)} />} label="Hide Clock Background" />
       <FormControl fullWidth size="small">
         <InputLabel>Circle Bar Progress</InputLabel>
         <Select value={circleProgress} label="Circle Bar Progress" onChange={(e) => setCircleProgress(e.target.value)}>
@@ -250,7 +250,7 @@ const MqtSetting = () => {
         fullWidth
         size="small"
         type="number"
-        label="+/- Time Step (seconds)"
+        label="+/− Time Step (seconds)"
         value={plusMinusStep}
         onChange={(e) => setPlusMinusStep(Math.max(1, parseInt(e.target.value) || 1))}
         inputProps={{ min: 1, max: 60 }}
@@ -275,9 +275,14 @@ const MqtSetting = () => {
         inputProps={{ min: 1, max: 3600 }}
         helperText="Timer turns yellow when remaining time ≤ this value"
       />
+      <FormControlLabel control={<Checkbox size="small" checked={allowClickableTimer} onChange={() => setAllowClickableTimer(!allowClickableTimer)} />} label="Allow Clickable Timer when running" />
+      <FormControlLabel control={<Checkbox size="small" checked={disableKeyboard} onChange={() => setDisableKeyboard(!disableKeyboard)} />} label="Disable Keyboard Shortcut" />
+      <FormControlLabel control={<Checkbox size="small" checked={hideClockBackground} onChange={() => setHideClockBackground(!hideClockBackground)} />} label="Hide Clock Background" />
+      <FormControlLabel control={<Checkbox size="small" checked={timeFormat === 'mm:ss'} onChange={() => setTimeFormat(timeFormat === 'mm:ss' ? 'mm' : 'mm:ss')} />} label="Ability to set seconds (MM:SS)" />
     </Stack>
   );
 
+  // SOUND preview
   const previewAudioRef = useRef(null);
   const handlePreviewSound = async () => {
     try {
@@ -306,73 +311,6 @@ const MqtSetting = () => {
       }
     };
   }, []);
-
-  const ExtraFunctionSettings = (
-    <Stack spacing={2}>
-      <FormControl fullWidth size="small">
-        <InputLabel>Background Theme</InputLabel>
-        <Select value={theme} label="Background Theme" onChange={(e) => setTheme(e.target.value)}>
-          <MenuItem value="black">Default (Black)</MenuItem>
-          <MenuItem value="emerald">Dark Blue</MenuItem>
-          <MenuItem value="purple">Purple</MenuItem>
-          <MenuItem value="green">Green</MenuItem>
-          <MenuItem value="white">White</MenuItem>
-          <MenuItem value="red">Red</MenuItem>
-          <MenuItem value="blue">Blue</MenuItem>
-        </Select>
-      </FormControl>
-      <FormControl fullWidth size="small">
-        <InputLabel>Font</InputLabel>
-        <Select value={font} label="Font" onChange={(e) => setFont(e.target.value)}>
-          <MenuItem value="Arial">Arial</MenuItem>
-          <MenuItem value="Times New Roman">Times New Roman</MenuItem>
-          <MenuItem value="Mono">Mono</MenuItem>
-          <MenuItem value="Thin">Thin</MenuItem>
-        </Select>
-      </FormControl>
-      <FormControl fullWidth size="small">
-        <InputLabel>Circle Style</InputLabel>
-        <Select value={circleStyle} label="Circle Style" onChange={(e) => setCircleStyle(e.target.value)}>
-          <MenuItem value="thin">Thin</MenuItem>
-          <MenuItem value="fat">Fat</MenuItem>
-          <MenuItem value="bw">B&W Minimalistic</MenuItem>
-        </Select>
-      </FormControl>
-      <Stack direction="row" spacing={1} alignItems="center">
-        <FormControl fullWidth size="small">
-          <InputLabel>Sound Set</InputLabel>
-          <Select value={soundSet} label="Sound Set" onChange={(e) => setSoundSet(parseInt(e.target.value))}>
-            <MenuItem value={0}>None</MenuItem>
-            <MenuItem value={1}>Set 1</MenuItem>
-            <MenuItem value={2}>Set 2</MenuItem>
-            <MenuItem value={3}>Set 3</MenuItem>
-            <MenuItem value={4}>Set 4</MenuItem>
-            <MenuItem value={5}>Set 5</MenuItem>
-          </Select>
-        </FormControl>
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={handlePreviewSound}
-          aria-label="Preview selected sound set"
-          title="Preview selected sound set"
-          disabled={soundSet === 0}
-        >
-          <span role="img" aria-label="speaker">🔊</span>
-        </Button>
-      </Stack>
-      <FormControl fullWidth size="small">
-        <InputLabel>Notification Sound Mod</InputLabel>
-        <Select value={warnMode} label="Notification Sound Mod" onChange={(e) => setWarnMode(e.target.value)}>
-          <MenuItem value="none">None</MenuItem>
-          <MenuItem value="10s">Last 10 Seconds</MenuItem>
-          <MenuItem value="1m">Last 1 Minute (once)</MenuItem>
-          <MenuItem value="5m">Last 5 Minutes (once)</MenuItem>
-        </Select>
-      </FormControl>
-      <FormControlLabel control={<Checkbox size="small" checked={startSoundEnabled} onChange={() => setStartSoundEnabled(!startSoundEnabled)} />} label="Enable Start Sound" />
-    </Stack>
-  );
 
   // Reset to defaults and clear saved settings
   const handleReset = () => {
@@ -409,64 +347,102 @@ const MqtSetting = () => {
     }
   };
 
-
   return (
-    <Box
-      sx={{
-        maxWidth: 600,
-        margin: '2rem auto',
-        background: '#fff',
-        borderRadius: '10px',
-        padding: '1.5rem',
-        boxShadow: '0 4px 16px rgba(0,0,0,0.1)'
-      }}
-    >
-      <Tabs
-        value={tabIndex}
-        onChange={handleTabChange}
-        variant="fullWidth"
-        textColor="primary"
-        indicatorColor="primary"
-        centered
-      >
-        <Tab label="⏲️ Timer Settings" />
-        <Tab label="⚙️ Function" />
-        <Tab label="🛠️ Extra Function" />
-      </Tabs>
+    <div className="mqt-settings-panel mqt-settings-wide">
+      <Typography component="h1" className="mqt-settings-title">Settings</Typography>
 
-      <Box sx={{ mt: 3 }}>
-        {tabIndex === 0 && TimerSettings}
-        {tabIndex === 1 && FunctionSettings}
-        {tabIndex === 2 && ExtraFunctionSettings}
-      </Box>
+      <div className="mqt-settings-grid">
+        <div>
+          <div className="settings-section">
+            <h3>Timer</h3>
+            {TimerSettings}
+          </div>
 
-      <Box sx={{ textAlign: 'center', mt: 4 }}>
-        <Button
-          variant="contained"
-          size="medium"
-          color="success"
-          onClick={handleStart}
-          sx={{ mr: 2 }} // Adds margin-right for spacing
-        >
-          Preview
-        </Button>
+          <div className="settings-section">
+            <h3>Functions</h3>
+            {FunctionSettings}
+          </div>
+        </div>
 
-        <Button
-          variant="outlined"
-          onClick={toggleFullscreen}
-          sx={{ mr: 2 }}
-        >
-          Fullscreen
-        </Button>
-        <Button
-          variant="outlined"
-          color="error"
-          onClick={handleReset}
-        >
-          Reset
-        </Button>
-      </Box>
-    </Box>
+        <div>
+          <div className="settings-section">
+            <h3>Timer Style</h3>
+            <FormControl fullWidth size="small">
+              <InputLabel>Circle Style</InputLabel>
+              <Select value={circleStyle} label="Circle Style" onChange={(e) => setCircleStyle(e.target.value)}>
+                <MenuItem value="thin">Thin</MenuItem>
+                <MenuItem value="fat">Fat</MenuItem>
+                <MenuItem value="bw">B&W Minimalistic</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth size="small">
+              <InputLabel>Font</InputLabel>
+              <Select value={font} label="Font" onChange={(e) => setFont(e.target.value)}>
+                <MenuItem value="Arial">Arial</MenuItem>
+                <MenuItem value="Times New Roman">Times New Roman</MenuItem>
+                <MenuItem value="Mono">Mono</MenuItem>
+                <MenuItem value="Thin">Thin</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth size="small">
+              <InputLabel>Background Theme</InputLabel>
+              <Select value={theme} label="Background Theme" onChange={(e) => setTheme(e.target.value)}>
+                <MenuItem value="black">Default (Black)</MenuItem>
+                <MenuItem value="emerald">Dark Blue</MenuItem>
+                <MenuItem value="purple">Purple</MenuItem>
+                <MenuItem value="green">Green</MenuItem>
+                <MenuItem value="white">White</MenuItem>
+                <MenuItem value="red">Red</MenuItem>
+                <MenuItem value="blue">Blue</MenuItem>
+              </Select>
+            </FormControl>
+          </div>
+
+          <div className="settings-section">
+            <h3>Sounds</h3>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <FormControl fullWidth size="small">
+                <InputLabel>Sound Set</InputLabel>
+                <Select value={soundSet} label="Sound Set" onChange={(e) => setSoundSet(parseInt(e.target.value))}>
+                  <MenuItem value={0}>None</MenuItem>
+                  <MenuItem value={1}>Set 1</MenuItem>
+                  <MenuItem value={2}>Set 2</MenuItem>
+                  <MenuItem value={3}>Set 3</MenuItem>
+                  <MenuItem value={4}>Set 4</MenuItem>
+                  <MenuItem value={5}>Set 5</MenuItem>
+                </Select>
+              </FormControl>
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handlePreviewSound}
+                aria-label="Preview selected sound set"
+                title="Preview selected sound set"
+                disabled={soundSet === 0}
+              >
+                <span role="img" aria-label="speaker">🔊</span>
+              </Button>
+            </Stack>
+            <FormControl fullWidth size="small">
+              <InputLabel>Notification Sound Mod</InputLabel>
+              <Select value={warnMode} label="Notification Sound Mod" onChange={(e) => setWarnMode(e.target.value)}>
+                <MenuItem value="none">None</MenuItem>
+                <MenuItem value="10s">Last 10 Seconds</MenuItem>
+                <MenuItem value="1m">Last 1 Minute (once)</MenuItem>
+                <MenuItem value="5m">Last 5 Minutes (once)</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControlLabel control={<Checkbox size="small" checked={startSoundEnabled} onChange={() => setStartSoundEnabled(!startSoundEnabled)} />} label="Enable Start Sound" />
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-actions">
+        <Button className="btn" variant="contained" size="medium" color="success" onClick={handleStart}>Preview</Button>
+        <Button className="btn" variant="outlined" onClick={toggleFullscreen}>Fullscreen</Button>
+        <Button className="btn" variant="outlined" color="error" onClick={handleReset}>Reset</Button>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -349,19 +349,19 @@ const MqtSetting = () => {
 
       <div className="mqt-settings-grid">
         <div>
-          <div className="settings-section">
+          <div className="settings-section settings-section-card">
             <h3>Functions</h3>
             {FunctionSettings}
           </div>
 
-          <div className="settings-section">
+          <div className="settings-section settings-section-card">
             <h3>Timer</h3>
             {TimerSettings}
           </div>
         </div>
 
         <div>
-          <div className="settings-section">
+          <div className="settings-section settings-section-card">
             <h3>Timer Style</h3>
             <Typography variant="body2">Circle Style</Typography>
             <Stack>

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  Box, Typography, Slider, Checkbox, FormControlLabel,
+  Typography, Slider, Checkbox, FormControlLabel,
   Select, MenuItem, TextField, Button, FormControl, InputLabel,
   Stack
 } from '@mui/material';

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -242,35 +242,37 @@ const MqtSetting = () => {
         <FormControlLabel control={<Checkbox size="small" checked={circleProgress === 'minute'} onChange={() => setCircleProgress('minute')} />} label="By Minute" />
       </Stack>
 
-      <TextField
-        fullWidth
-        size="small"
-        type="number"
-        label="+/− Time Step (seconds)"
-        value={plusMinusStep}
-        onChange={(e) => setPlusMinusStep(Math.max(1, parseInt(e.target.value) || 1))}
-        inputProps={{ min: 1, max: 60 }}
-      />
-      <TextField
-        fullWidth
-        size="small"
-        type="number"
-        label="Red Color Trigger (seconds)"
-        value={redTrigger}
-        {...createNumberInputHandler(setRedTrigger, 1, 3600, 60)}
-        inputProps={{ min: 1, max: 3600 }}
-        helperText="Timer turns red when remaining time ≤ this value"
-      />
-      <TextField
-        fullWidth
-        size="small"
-        type="number"
-        label="Yellow Color Trigger (seconds)"
-        value={yellowTrigger}
-        {...createNumberInputHandler(setYellowTrigger, 1, 3600, 300)}
-        inputProps={{ min: 1, max: 3600 }}
-        helperText="Timer turns yellow when remaining time ≤ this value"
-      />
+      <div className="inline-fields">
+        <TextField
+          fullWidth
+          size="small"
+          type="number"
+          label="+/− Time Step (seconds)"
+          value={plusMinusStep}
+          onChange={(e) => setPlusMinusStep(Math.max(1, parseInt(e.target.value) || 1))}
+          inputProps={{ min: 1, max: 60 }}
+        />
+        <TextField
+          fullWidth
+          size="small"
+          type="number"
+          label="Red Color Trigger (seconds)"
+          value={redTrigger}
+          {...createNumberInputHandler(setRedTrigger, 1, 3600, 60)}
+          inputProps={{ min: 1, max: 3600 }}
+          helperText="Timer turns red when remaining time ≤ this value"
+        />
+        <TextField
+          fullWidth
+          size="small"
+          type="number"
+          label="Yellow Color Trigger (seconds)"
+          value={yellowTrigger}
+          {...createNumberInputHandler(setYellowTrigger, 1, 3600, 300)}
+          inputProps={{ min: 1, max: 3600 }}
+          helperText="Timer turns yellow when remaining time ≤ this value"
+        />
+      </div>
       <FormControlLabel control={<Checkbox size="small" checked={allowClickableTimer} onChange={() => setAllowClickableTimer(!allowClickableTimer)} />} label="Enable time setting even when timer is running" />
       <FormControlLabel control={<Checkbox size="small" checked={disableKeyboard} onChange={() => setDisableKeyboard(!disableKeyboard)} />} label="Disable keyboard control" />
       <FormControlLabel control={<Checkbox size="small" checked={hideClockBackground} onChange={() => setHideClockBackground(!hideClockBackground)} />} label="Hide Clock Background" />

--- a/src/components/MqtSetting.js
+++ b/src/components/MqtSetting.js
@@ -2,8 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Typography, Slider, Checkbox, FormControlLabel,
-  Select, MenuItem, TextField, Button, FormControl, InputLabel,
-  Stack
+  TextField, Button, Stack
 } from '@mui/material';
 import './MqtLayout.css';
 
@@ -56,7 +55,7 @@ const MqtSetting = () => {
 
   // Load saved settings or use defaults
   const savedSettings = loadSettings() || {};
-  const [tabIndex, setTabIndex] = useState(savedSettings.tabIndex || 0); // preserved for storage compatibility
+  const [tabIndex, setTabIndex] = useState(savedSettings.tabIndex || 0); // storage compatibility
   const initialDurationSec = (() => {
     const raw = savedSettings.duration ?? 600; // default 10 minutes in seconds
     if (savedSettings.durationUnit === 'sec') return Math.max(1, raw);
@@ -222,30 +221,27 @@ const MqtSetting = () => {
         </>
       )}
 
-      <FormControl fullWidth size="small">
-        <InputLabel>Time Format</InputLabel>
-        <Select value={timeFormat} label="Time Format" onChange={(e) => setTimeFormat(e.target.value)}>
-          <MenuItem value="mm">MM</MenuItem>
-          <MenuItem value="mm:ss">MM:SS</MenuItem>
-        </Select>
-      </FormControl>
+      <Typography variant="body2">Time Format</Typography>
+      <Stack direction="row" spacing={2}>
+        <FormControlLabel control={<Checkbox size="small" checked={timeFormat === 'mm'} onChange={() => setTimeFormat('mm')} />} label="MM" />
+        <FormControlLabel control={<Checkbox size="small" checked={timeFormat === 'mm:ss'} onChange={() => setTimeFormat('mm:ss')} />} label="MM:SS" />
+      </Stack>
 
-      <FormControlLabel control={<Checkbox size="small" checked={autoRestart} onChange={() => setAutoRestart(!autoRestart)} />} label="Auto Restart" />
+      <FormControlLabel control={<Checkbox size="small" checked={autoRestart} onChange={() => setAutoRestart(!autoRestart)} />} label="Autorestart" />
       <FormControlLabel control={<Checkbox size="small" checked={countUp} onChange={() => setCountUp(!countUp)} />} label="Count Up (Reverse)" />
-      <FormControlLabel control={<Checkbox size="small" checked={limitBreak} onChange={() => setLimitBreak(!limitBreak)} />} label="Limit Break (exceed 120 min)" />
+      <FormControlLabel control={<Checkbox size="small" checked={limitBreak} onChange={() => setLimitBreak(!limitBreak)} />} label="Go over 120 minute limit" />
     </Stack>
   );
 
   // SECTION: Functional controls
   const FunctionSettings = (
     <Stack spacing={2}>
-      <FormControl fullWidth size="small">
-        <InputLabel>Circle Bar Progress</InputLabel>
-        <Select value={circleProgress} label="Circle Bar Progress" onChange={(e) => setCircleProgress(e.target.value)}>
-          <MenuItem value="full">Full Time</MenuItem>
-          <MenuItem value="minute">By Minute</MenuItem>
-        </Select>
-      </FormControl>
+      <Typography variant="body2">Circle Bar Progress</Typography>
+      <Stack direction="row" spacing={2}>
+        <FormControlLabel control={<Checkbox size="small" checked={circleProgress === 'full'} onChange={() => setCircleProgress('full')} />} label="Full Time" />
+        <FormControlLabel control={<Checkbox size="small" checked={circleProgress === 'minute'} onChange={() => setCircleProgress('minute')} />} label="By Minute" />
+      </Stack>
+
       <TextField
         fullWidth
         size="small"
@@ -275,10 +271,10 @@ const MqtSetting = () => {
         inputProps={{ min: 1, max: 3600 }}
         helperText="Timer turns yellow when remaining time ≤ this value"
       />
-      <FormControlLabel control={<Checkbox size="small" checked={allowClickableTimer} onChange={() => setAllowClickableTimer(!allowClickableTimer)} />} label="Allow Clickable Timer when running" />
-      <FormControlLabel control={<Checkbox size="small" checked={disableKeyboard} onChange={() => setDisableKeyboard(!disableKeyboard)} />} label="Disable Keyboard Shortcut" />
+      <FormControlLabel control={<Checkbox size="small" checked={allowClickableTimer} onChange={() => setAllowClickableTimer(!allowClickableTimer)} />} label="Enable time setting even when timer is running" />
+      <FormControlLabel control={<Checkbox size="small" checked={disableKeyboard} onChange={() => setDisableKeyboard(!disableKeyboard)} />} label="Disable keyboard control" />
       <FormControlLabel control={<Checkbox size="small" checked={hideClockBackground} onChange={() => setHideClockBackground(!hideClockBackground)} />} label="Hide Clock Background" />
-      <FormControlLabel control={<Checkbox size="small" checked={timeFormat === 'mm:ss'} onChange={() => setTimeFormat(timeFormat === 'mm:ss' ? 'mm' : 'mm:ss')} />} label="Ability to set seconds (MM:SS)" />
+      <FormControlLabel control={<Checkbox size="small" checked={timeFormat === 'mm:ss'} onChange={() => setTimeFormat(timeFormat === 'mm:ss' ? 'mm' : 'mm:ss')} />} label="Ability to set seconds" />
     </Stack>
   );
 
@@ -354,84 +350,66 @@ const MqtSetting = () => {
       <div className="mqt-settings-grid">
         <div>
           <div className="settings-section">
-            <h3>Timer</h3>
-            {TimerSettings}
+            <h3>Functions</h3>
+            {FunctionSettings}
           </div>
 
           <div className="settings-section">
-            <h3>Functions</h3>
-            {FunctionSettings}
+            <h3>Timer</h3>
+            {TimerSettings}
           </div>
         </div>
 
         <div>
           <div className="settings-section">
             <h3>Timer Style</h3>
-            <FormControl fullWidth size="small">
-              <InputLabel>Circle Style</InputLabel>
-              <Select value={circleStyle} label="Circle Style" onChange={(e) => setCircleStyle(e.target.value)}>
-                <MenuItem value="thin">Thin</MenuItem>
-                <MenuItem value="fat">Fat</MenuItem>
-                <MenuItem value="bw">B&W Minimalistic</MenuItem>
-              </Select>
-            </FormControl>
-            <FormControl fullWidth size="small">
-              <InputLabel>Font</InputLabel>
-              <Select value={font} label="Font" onChange={(e) => setFont(e.target.value)}>
-                <MenuItem value="Arial">Arial</MenuItem>
-                <MenuItem value="Times New Roman">Times New Roman</MenuItem>
-                <MenuItem value="Mono">Mono</MenuItem>
-                <MenuItem value="Thin">Thin</MenuItem>
-              </Select>
-            </FormControl>
-            <FormControl fullWidth size="small">
-              <InputLabel>Background Theme</InputLabel>
-              <Select value={theme} label="Background Theme" onChange={(e) => setTheme(e.target.value)}>
-                <MenuItem value="black">Default (Black)</MenuItem>
-                <MenuItem value="emerald">Dark Blue</MenuItem>
-                <MenuItem value="purple">Purple</MenuItem>
-                <MenuItem value="green">Green</MenuItem>
-                <MenuItem value="white">White</MenuItem>
-                <MenuItem value="red">Red</MenuItem>
-                <MenuItem value="blue">Blue</MenuItem>
-              </Select>
-            </FormControl>
+            <Typography variant="body2">Circle Style</Typography>
+            <Stack>
+              <FormControlLabel control={<Checkbox size="small" checked={circleStyle === 'thin'} onChange={() => setCircleStyle('thin')} />} label="Thin" />
+              <FormControlLabel control={<Checkbox size="small" checked={circleStyle === 'fat'} onChange={() => setCircleStyle('fat')} />} label="Fat" />
+              <FormControlLabel control={<Checkbox size="small" checked={circleStyle === 'bw'} onChange={() => setCircleStyle('bw')} />} label="B&W minimalistic" />
+            </Stack>
+
+            <Typography variant="body2" sx={{ mt: 1 }}>Font</Typography>
+            <Stack>
+              <FormControlLabel control={<Checkbox size="small" checked={font === 'Arial'} onChange={() => setFont('Arial')} />} label="Arial" />
+              <FormControlLabel control={<Checkbox size="small" checked={font === 'Times New Roman'} onChange={() => setFont('Times New Roman')} />} label="Times New Roman" />
+              <FormControlLabel control={<Checkbox size="small" checked={font === 'Mono'} onChange={() => setFont('Mono')} />} label="Mono" />
+              <FormControlLabel control={<Checkbox size="small" checked={font === 'Thin'} onChange={() => setFont('Thin')} />} label="Thin" />
+            </Stack>
+
+            <Typography variant="body2" sx={{ mt: 1 }}>Background Theme</Typography>
+            <Stack>
+              <FormControlLabel control={<Checkbox size="small" checked={theme === 'black'} onChange={() => setTheme('black')} />} label="Default (Black)" />
+              <FormControlLabel control={<Checkbox size="small" checked={theme === 'emerald'} onChange={() => setTheme('emerald')} />} label="Dark Blue" />
+              <FormControlLabel control={<Checkbox size="small" checked={theme === 'purple'} onChange={() => setTheme('purple')} />} label="Purple" />
+              <FormControlLabel control={<Checkbox size="small" checked={theme === 'green'} onChange={() => setTheme('green')} />} label="Green" />
+              <FormControlLabel control={<Checkbox size="small" checked={theme === 'white'} onChange={() => setTheme('white')} />} label="White" />
+              <FormControlLabel control={<Checkbox size="small" checked={theme === 'red'} onChange={() => setTheme('red')} />} label="Red" />
+              <FormControlLabel control={<Checkbox size="small" checked={theme === 'blue'} onChange={() => setTheme('blue')} />} label="Blue" />
+            </Stack>
           </div>
 
           <div className="settings-section">
             <h3>Sounds</h3>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <FormControl fullWidth size="small">
-                <InputLabel>Sound Set</InputLabel>
-                <Select value={soundSet} label="Sound Set" onChange={(e) => setSoundSet(parseInt(e.target.value))}>
-                  <MenuItem value={0}>None</MenuItem>
-                  <MenuItem value={1}>Set 1</MenuItem>
-                  <MenuItem value={2}>Set 2</MenuItem>
-                  <MenuItem value={3}>Set 3</MenuItem>
-                  <MenuItem value={4}>Set 4</MenuItem>
-                  <MenuItem value={5}>Set 5</MenuItem>
-                </Select>
-              </FormControl>
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={handlePreviewSound}
-                aria-label="Preview selected sound set"
-                title="Preview selected sound set"
-                disabled={soundSet === 0}
-              >
-                <span role="img" aria-label="speaker">🔊</span>
-              </Button>
+            <Typography variant="body2">Sound Set</Typography>
+            <Stack>
+              <FormControlLabel control={<Checkbox size="small" checked={soundSet === 0} onChange={() => setSoundSet(0)} />} label="None" />
+              <FormControlLabel control={<Checkbox size="small" checked={soundSet === 1} onChange={() => setSoundSet(1)} />} label="Sound 1" />
+              <FormControlLabel control={<Checkbox size="small" checked={soundSet === 2} onChange={() => setSoundSet(2)} />} label="Sound 2" />
+              <FormControlLabel control={<Checkbox size="small" checked={soundSet === 3} onChange={() => setSoundSet(3)} />} label="Sound 3" />
+              <FormControlLabel control={<Checkbox size="small" checked={soundSet === 4} onChange={() => setSoundSet(4)} />} label="Sound 4" />
+              <FormControlLabel control={<Checkbox size="small" checked={soundSet === 5} onChange={() => setSoundSet(5)} />} label="Sound 5" />
             </Stack>
-            <FormControl fullWidth size="small">
-              <InputLabel>Notification Sound Mod</InputLabel>
-              <Select value={warnMode} label="Notification Sound Mod" onChange={(e) => setWarnMode(e.target.value)}>
-                <MenuItem value="none">None</MenuItem>
-                <MenuItem value="10s">Last 10 Seconds</MenuItem>
-                <MenuItem value="1m">Last 1 Minute (once)</MenuItem>
-                <MenuItem value="5m">Last 5 Minutes (once)</MenuItem>
-              </Select>
-            </FormControl>
+            <Button variant="outlined" size="small" onClick={handlePreviewSound} aria-label="Preview selected sound set" title="Preview selected sound set" disabled={soundSet === 0}>🔊</Button>
+
+            <Typography variant="body2" sx={{ mt: 1 }}>Notification sound</Typography>
+            <Stack>
+              <FormControlLabel control={<Checkbox size="small" checked={warnMode === 'none'} onChange={() => setWarnMode('none')} />} label="None" />
+              <FormControlLabel control={<Checkbox size="small" checked={warnMode === '10s'} onChange={() => setWarnMode('10s')} />} label="Last 10 seconds" />
+              <FormControlLabel control={<Checkbox size="small" checked={warnMode === '1m'} onChange={() => setWarnMode('1m')} />} label="Last 1 minute (once)" />
+              <FormControlLabel control={<Checkbox size="small" checked={warnMode === '5m'} onChange={() => setWarnMode('5m')} />} label="Last 5 minutes (once)" />
+            </Stack>
             <FormControlLabel control={<Checkbox size="small" checked={startSoundEnabled} onChange={() => setStartSoundEnabled(!startSoundEnabled)} />} label="Enable Start Sound" />
           </div>
         </div>


### PR DESCRIPTION
## Purpose
The user requested a complete redesign of the settings page to improve its visual appearance and usability. The main goals were to:
- Convert dropdown menus to checkbox-based selections for better user experience
- Change the color scheme from white to black with appropriate contrast adjustments
- Enlarge the settings container and improve the overall layout organization
- Remove the Timer Duration setting while preserving display functionality
- Fix visibility issues with Time Step, Red Color, and Yellow Color Trigger options

## Code changes
- **Dark theme implementation**: Changed background from white (#ffffff) to black (#000000) with white text and updated all MUI component styles for proper contrast
- **Layout restructure**: Replaced tabbed interface with a two-column grid layout using CSS Grid, added section cards for better visual grouping
- **Checkbox conversion**: Converted all dropdown selectors (time format, circle style, font, theme, sound set, notification mode) to checkbox-based selections
- **Container expansion**: Increased max-width from 600px to 1200px with responsive design breakpoints
- **Timer Duration removal**: Surgically removed timer duration controls and sliders while maintaining all display timer functionality
- **Enhanced styling**: Added new CSS classes for section organization, improved spacing, and better visual hierarchy with section headers and bordersTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d0bad76f14cd463fbab9fe0ffcfd9e0e/nova-zone)

👀 [Preview Link](https://d0bad76f14cd463fbab9fe0ffcfd9e0e-nova-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d0bad76f14cd463fbab9fe0ffcfd9e0e</projectId>-->
<!--<branchName>nova-zone</branchName>-->